### PR TITLE
fix: Async filters not working

### DIFF
--- a/lib/webpack/pangolin-loader.js
+++ b/lib/webpack/pangolin-loader.js
@@ -36,7 +36,8 @@ nunjucksEnvironment.addExtension('static', new StaticExtension())
 for (const filter in store.state.config.nunjucks.filters) {
   nunjucksEnvironment.addFilter(
     filter,
-    store.state.config.nunjucks.filters[filter]
+    store.state.config.nunjucks.filters[filter],
+    store.state.config.nunjucks.filters[filter].constructor.name === 'AsyncFunction'
   )
 }
 


### PR DESCRIPTION
Set the third parameter of `nunjucksEnvironment.addFilter` to true, if the filter is an async function and false otherwise.